### PR TITLE
Fix 'webxml attribute is required' when packaging WAR

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -409,6 +409,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.2</version>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
Without the below configuration of the `maven-war-plugin`, the `backend` build is failing on my machine. 