### PR TITLE
Fix simulator and use send-to-backend flag for responder generation

### DIFF
--- a/simulator/src/main/java/org/cajun/navy/util/Disaster.java
+++ b/simulator/src/main/java/org/cajun/navy/util/Disaster.java
@@ -45,8 +45,9 @@ public class Disaster {
                 .medicalNeeded(new Random().nextBoolean())
                 .build();
 
-        if(send)
-        backendService.createIncident(incident);
+        if(send) {
+            backendService.createIncident(incident);
+        }
 
         return incident;
 
@@ -61,7 +62,7 @@ public class Disaster {
 
     public Responder generateResponder() {
         Point2D.Double point = points.getInternalPoint();
-        return new Responder.Builder()
+        Responder responder = new Responder.Builder()
                 .name(fullNames.getNextFullName())
                 .phoneNumber(GeneratePhoneNumbers.getNextPhoneNumber())
                 .boatCapacity(biasedRandom(1, 12, 0.5))
@@ -72,10 +73,14 @@ public class Disaster {
                 .person(false)
                 .available(true)
                 .build();
+        if (send) {
+            backendService.createResponder(responder);
+        }
+        return responder;
     }
 
 
-    public List<Incident> generateIncidents(int number, boolean send){
+    public List<Incident> generateIncidents(int number){
         List<Incident> incidents = new ArrayList<Incident>(number);
         for(int i=0; i<number; i++)
             incidents.add(generateSingleIncident());

--- a/simulator/src/main/java/org/cajun/navy/util/GeneratorResource.java
+++ b/simulator/src/main/java/org/cajun/navy/util/GeneratorResource.java
@@ -17,15 +17,14 @@ public class GeneratorResource {
     @Path("incidents/{number}")
     @Produces(MediaType.APPLICATION_JSON)
     public List<Incident> incidents(@PathParam("number") int numOfIncidents) {
-       return disaster.generateIncidents(numOfIncidents, true);
+       return disaster.generateIncidents(numOfIncidents);
     }
 
     @GET
     @Path("responders/{number}/")
     @Produces(MediaType.APPLICATION_JSON)
     public List<Responder> responders(@PathParam("number") int numOfResponders) {
-        Disaster d = new Disaster();
-        return d.generateResponders(numOfResponders);
+        return disaster.generateResponders(numOfResponders);
     }
 
 }


### PR DESCRIPTION
The `GeneratorResource` used a new instance of `Disaster` for each request. I wonder if that was intentional. I changed that to use the injected `Disaster` instance. This way, the `sendRestToBackend` config flag is respected. 