### PR TITLE
Add flag to disable ResponderSimulatorTask

### DIFF
--- a/backend/src/main/java/org/cajun/navy/model/responder/ResponderSimulatorTask.java
+++ b/backend/src/main/java/org/cajun/navy/model/responder/ResponderSimulatorTask.java
@@ -2,9 +2,15 @@ package org.cajun.navy.model.responder;
 
 import org.cajun.navy.model.mission.MissionEntity;
 import org.cajun.navy.service.MissionService;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import javax.ejb.Schedule;
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.ejb.ScheduleExpression;
 import javax.ejb.Singleton;
+import javax.ejb.Timeout;
+import javax.ejb.TimerConfig;
+import javax.ejb.TimerService;
 import javax.inject.Inject;
 import java.util.List;
 import java.util.logging.Logger;
@@ -14,10 +20,29 @@ public class ResponderSimulatorTask {
 
     private static final Logger logger = Logger.getLogger(ResponderSimulatorTask.class.getName());
 
+    @Resource
+    TimerService timerService;
+
     @Inject
     MissionService missionService;
 
-    @Schedule(second = "*/5", minute = "*", hour = "*", persistent = false)
+    @Inject
+    @ConfigProperty(name = "responder.simulator.task.active", defaultValue = "true")
+    private boolean active;
+
+    @PostConstruct
+    void init() {
+        if (active) {
+            ScheduleExpression expression = new ScheduleExpression().second("*/5").minute("*").hour("*");
+            TimerConfig timerConfig = new TimerConfig();
+            timerConfig.setPersistent(true);
+            timerService.createCalendarTimer(expression, timerConfig);
+        } else {
+            logger.info("Disable ResponderSimulatorTask");
+        }
+    }
+
+    @Timeout
     public void doMoveResponderLocation(){
         List<MissionEntity> missions = missionService.getAllCreatedOrUpdated();
         logger.info("Are there any missions for next move? "+missions.size());

--- a/backend/src/main/resources/META-INF/microprofile-config.properties
+++ b/backend/src/main/resources/META-INF/microprofile-config.properties
@@ -48,3 +48,6 @@ mp.messaging.connector.smallrye-kafka.group.id="frdemo"
 # mapbox token
 mapbox.token=pk.eyJ1Ijoic3NoYWFmIiwiYSI6ImNsOHN2bmUwczAxNWszb3FyZmo1cTRob3cifQ.r0fQUumuAM773uUKnHMHyQ
 
+# boolean flag whether to execute the responder simulator task
+# org.cajun.navy.model.responder.ResponderSimulatorTask
+responder.simulator.task.active=${RESPONDER_SIMULATOR_TASK:true}


### PR DESCRIPTION
This PR adds the configuration property `responder.simulator.task.active` backed by the system property `RESPONDER_SIMULATOR_TASK` to disable the EJB singleton task `ResponderSimulatorTask`. 

The background is to enable cluster-wide performance tests w/o side effects. 