### PR TITLE
Set managed Jsonb provider

### DIFF
--- a/backend/src/main/java/org/cajun/navy/resource/JsonbContextResolver.java
+++ b/backend/src/main/java/org/cajun/navy/resource/JsonbContextResolver.java
@@ -1,0 +1,20 @@
+package org.cajun.navy.resource;
+
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.ws.rs.ext.ContextResolver;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class JsonbContextResolver implements ContextResolver<Jsonb> {
+    private final Jsonb jsonb;
+
+    public JsonbContextResolver() {
+        jsonb = JsonbBuilder.create();
+    }
+
+    @Override
+    public Jsonb getContext(Class<?> aClass) {
+        return jsonb;
+    }
+}


### PR DESCRIPTION
This seems to be a workaround to the problem raised https://github.com/wildfly-extras/first-responder-demo/pull/17, in particular https://github.com/wildfly-extras/first-responder-demo/pull/17#issuecomment-3244288537.

With this fix we are injecting a default/managed `Jsonb` instance avoiding Resteasy to keep calling `getDelegate` everytime a new response needs to be serialized causing quite evident degradation in the performance of this very simple application.

As mentioned I think this is just a workaround as I was expecting Resteasy to cache the Jsonb even when not explicitly provided but since I am not that familiar on this part I'd like to get some other feedback on the best approach here.

**Before**
<img width="2855" height="979" alt="image" src="https://github.com/user-attachments/assets/70526e05-a7ee-4056-847d-a36d898be610" />


**After**
<img width="2855" height="979" alt="image" src="https://github.com/user-attachments/assets/79d662c0-47d7-47d1-bdff-2eaaa789781e" />
